### PR TITLE
Updated to use Blender 4.3.2

### DIFF
--- a/addons/io_scene_swbf_msh/__init__.py
+++ b/addons/io_scene_swbf_msh/__init__.py
@@ -2,7 +2,7 @@ bl_info = {
     'name': 'SWBF .msh Import-Export',
     'author': 'Will Snyder, PrismaticFlower',
     "version": (1, 3, 3),
-    'blender': (3, 0, 0),
+    'blender': (4, 3, 2),
     'location': 'File > Import-Export',
     'description': 'Export as SWBF .msh file',
     'warning': '',

--- a/addons/io_scene_swbf_msh/msh_anim_to_blend.py
+++ b/addons/io_scene_swbf_msh/msh_anim_to_blend.py
@@ -107,4 +107,4 @@ def extract_and_apply_anim(filename : str, scene : Scene):
 
         arma.animation_data.action = action
         track = arma.animation_data.nla_tracks.new()
-        track.strips.new(action.name, action.frame_range[0], action)
+        track.strips.new(action.name, int(action.frame_range[0]), action)

--- a/addons/io_scene_swbf_msh/msh_mesh_to_blend.py
+++ b/addons/io_scene_swbf_msh/msh_mesh_to_blend.py
@@ -128,7 +128,6 @@ def model_to_mesh_object(model: Model, scene : Scene, materials_map : Dict[str, 
         blender_mesh.loops.foreach_set("vertex_index", flat_indices)
 
         # Normals
-        blender_mesh.create_normals_split()
         blender_mesh.loops.foreach_set("normal", [component for i in flat_indices for component in vertex_normals[i]])
 
         # UVs
@@ -175,7 +174,6 @@ def model_to_mesh_object(model: Model, scene : Scene, materials_map : Dict[str, 
         reset_normals = [0.0] * (len(blender_mesh.loops) * 3)
         blender_mesh.loops.foreach_get("normal", reset_normals)
         blender_mesh.normals_split_custom_set(tuple(zip(*(iter(reset_normals),) * 3)))
-        blender_mesh.use_auto_smooth = True
 
 
     blender_mesh_object = bpy.data.objects.new(model.name, blender_mesh)
@@ -198,4 +196,3 @@ def model_to_mesh_object(model: Model, scene : Scene, materials_map : Dict[str, 
 
 
     return blender_mesh_object
-


### PR DESCRIPTION
Bumped Blender compatible version to  4.3.2

Source Info:
https://developer.blender.org/docs/release_notes/4.1/python_api/#mesh

Removed:   create_normals_split
Note: "create_normals_split, calc_normals_split, and free_normals_split are removed, and are replaced by the simpler Mesh.corner_normals collection property. Since it gives access to the normals cache, it is automatically updated when relevant data changes."

Removed:   use_auto_smooth
Note:  "use_auto_smooth is removed. Face corner normals are now used automatically if there are mixed smooth vs. not smooth tags. Meshes now always use custom normals if they exist."

Had to update:  track.strips.new
Note: Threw errors on importing animations regarding float to int differences so casting to int now.

